### PR TITLE
Add BTCUSDT SMA and RSI example strategies

### DIFF
--- a/examples/backtest/crypto_rsi_btcusdt.py
+++ b/examples/backtest/crypto_rsi_btcusdt.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+"""Backtest for BTC/USDT RSI strategy."""
+
+import time
+from decimal import Decimal
+
+import pandas as pd
+
+from nautilus_trader.adapters.binance import BINANCE_VENUE
+from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.backtest.engine import BacktestEngineConfig
+from nautilus_trader.examples.strategies.rsi_mean_reversion import RSIMeanReversion
+from nautilus_trader.examples.strategies.rsi_mean_reversion import RSIMeanReversionConfig
+from nautilus_trader.model.currencies import BTC
+from nautilus_trader.model.currencies import USDT
+from nautilus_trader.model.data import BarType
+from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import OmsType
+from nautilus_trader.model.identifiers import TraderId
+from nautilus_trader.model.objects import Money
+from nautilus_trader.persistence.wranglers import TradeTickDataWrangler
+from nautilus_trader.test_kit.providers import TestDataProvider
+from nautilus_trader.test_kit.providers import TestInstrumentProvider
+
+
+if __name__ == "__main__":
+    # Configure backtest engine
+    config = BacktestEngineConfig(trader_id=TraderId("BACKTESTER-001"))
+
+    # Build the backtest engine
+    engine = BacktestEngine(config=config)
+
+    # Add a trading venue (multiple venues possible)
+    engine.add_venue(
+        venue=BINANCE_VENUE,
+        oms_type=OmsType.NETTING,
+        account_type=AccountType.CASH,
+        base_currency=None,
+        starting_balances=[Money(1_000_000.0, USDT), Money(10.0, BTC)],
+    )
+
+    # Add instruments
+    BTCUSDT_BINANCE = TestInstrumentProvider.btcusdt_binance()
+    engine.add_instrument(BTCUSDT_BINANCE)
+
+    # Add data
+    provider = TestDataProvider()
+    wrangler = TradeTickDataWrangler(instrument=BTCUSDT_BINANCE)
+    ticks = wrangler.process(provider.read_parquet_ticks("binance/btcusdt-trades.parquet"))
+    engine.add_data(ticks)
+
+    # Strategy configuration
+    trade_size = Decimal("0.01")  # Easily adjust trade amount here
+    config = RSIMeanReversionConfig(
+        instrument_id=BTCUSDT_BINANCE.id,
+        bar_type=BarType.from_str("BTCUSDT.BINANCE-100-TICK-LAST-INTERNAL"),
+        trade_size=trade_size,
+        rsi_period=14,
+        overbought=70,
+        oversold=30,
+    )
+
+    # Instantiate and add the strategy
+    strategy = RSIMeanReversion(config=config)
+    engine.add_strategy(strategy=strategy)
+
+    time.sleep(0.1)
+    input("Press Enter to continue...")
+
+    # Run the engine
+    engine.run()
+
+    # Optionally view reports
+    with pd.option_context(
+        "display.max_rows",
+        100,
+        "display.max_columns",
+        None,
+        "display.width",
+        300,
+    ):
+        print(engine.trader.generate_account_report(BINANCE_VENUE))
+        print(engine.trader.generate_order_fills_report())
+        print(engine.trader.generate_positions_report())
+
+    engine.reset()
+    engine.dispose()

--- a/examples/backtest/crypto_sma_cross_btcusdt.py
+++ b/examples/backtest/crypto_sma_cross_btcusdt.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+"""Backtest for BTC/USDT SMA cross strategy."""
+
+import time
+from decimal import Decimal
+
+import pandas as pd
+
+from nautilus_trader.adapters.binance import BINANCE_VENUE
+from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.backtest.engine import BacktestEngineConfig
+from nautilus_trader.examples.strategies.sma_cross import SMACross
+from nautilus_trader.examples.strategies.sma_cross import SMACrossConfig
+from nautilus_trader.model.currencies import BTC
+from nautilus_trader.model.currencies import USDT
+from nautilus_trader.model.data import BarType
+from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import OmsType
+from nautilus_trader.model.identifiers import TraderId
+from nautilus_trader.model.objects import Money
+from nautilus_trader.persistence.wranglers import TradeTickDataWrangler
+from nautilus_trader.test_kit.providers import TestDataProvider
+from nautilus_trader.test_kit.providers import TestInstrumentProvider
+
+
+if __name__ == "__main__":
+    # Configure backtest engine
+    config = BacktestEngineConfig(trader_id=TraderId("BACKTESTER-001"))
+
+    # Build the backtest engine
+    engine = BacktestEngine(config=config)
+
+    # Add a trading venue (multiple venues possible)
+    engine.add_venue(
+        venue=BINANCE_VENUE,
+        oms_type=OmsType.NETTING,
+        account_type=AccountType.CASH,
+        base_currency=None,
+        starting_balances=[Money(1_000_000.0, USDT), Money(10.0, BTC)],
+    )
+
+    # Add instruments
+    BTCUSDT_BINANCE = TestInstrumentProvider.btcusdt_binance()
+    engine.add_instrument(BTCUSDT_BINANCE)
+
+    # Add data
+    provider = TestDataProvider()
+    wrangler = TradeTickDataWrangler(instrument=BTCUSDT_BINANCE)
+    ticks = wrangler.process(provider.read_parquet_ticks("binance/btcusdt-trades.parquet"))
+    engine.add_data(ticks)
+
+    # Strategy configuration
+    trade_size = Decimal("0.01")  # Easily adjust trade amount here
+    config = SMACrossConfig(
+        instrument_id=BTCUSDT_BINANCE.id,
+        bar_type=BarType.from_str("BTCUSDT.BINANCE-100-TICK-LAST-INTERNAL"),
+        trade_size=trade_size,
+        fast_sma_period=10,
+        slow_sma_period=20,
+    )
+
+    # Instantiate and add the strategy
+    strategy = SMACross(config=config)
+    engine.add_strategy(strategy=strategy)
+
+    time.sleep(0.1)
+    input("Press Enter to continue...")
+
+    # Run the engine
+    engine.run()
+
+    # Optionally view reports
+    with pd.option_context(
+        "display.max_rows",
+        100,
+        "display.max_columns",
+        None,
+        "display.width",
+        300,
+    ):
+        print(engine.trader.generate_account_report(BINANCE_VENUE))
+        print(engine.trader.generate_order_fills_report())
+        print(engine.trader.generate_positions_report())
+
+    engine.reset()
+    engine.dispose()

--- a/nautilus_trader/examples/strategies/rsi_mean_reversion.py
+++ b/nautilus_trader/examples/strategies/rsi_mean_reversion.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+"""Relative strength index mean reversion example strategy."""
+
+from decimal import Decimal
+
+import pandas as pd
+
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.config import PositiveInt
+from nautilus_trader.config import StrategyConfig
+from nautilus_trader.core.correctness import PyCondition
+from nautilus_trader.indicators.rsi import RelativeStrengthIndex
+from nautilus_trader.model.data import Bar
+from nautilus_trader.model.data import BarType
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.instruments import Instrument
+from nautilus_trader.model.objects import Quantity
+from nautilus_trader.model.orders import MarketOrder
+from nautilus_trader.trading.strategy import Strategy
+
+
+# *** THIS IS A TEST STRATEGY WITH NO ALPHA ADVANTAGE WHATSOEVER. ***
+# *** IT IS NOT INTENDED TO BE USED TO TRADE LIVE WITH REAL MONEY. ***
+
+
+class RSIMeanReversionConfig(StrategyConfig, frozen=True):
+    """Configuration for ``RSIMeanReversion`` instances."""
+
+    instrument_id: InstrumentId
+    bar_type: BarType
+    trade_size: Decimal
+    rsi_period: PositiveInt = 14
+    overbought: PositiveInt = 70
+    oversold: PositiveInt = 30
+    request_bars: bool = True
+    order_time_in_force: TimeInForce | None = None
+    order_quantity_precision: int | None = None
+    close_positions_on_stop: bool = True
+
+
+class RSIMeanReversion(Strategy):
+    """A naive RSI mean reversion strategy."""
+
+    def __init__(self, config: RSIMeanReversionConfig) -> None:
+        PyCondition.is_true(config.overbought > config.oversold, "overbought must be > oversold")
+        super().__init__(config)
+
+        self.instrument: Instrument | None = None
+        self.rsi = RelativeStrengthIndex(config.rsi_period)
+
+    def on_start(self) -> None:
+        self.instrument = self.cache.instrument(self.config.instrument_id)
+        if self.instrument is None:
+            self.log.error(f"Could not find instrument for {self.config.instrument_id}")
+            self.stop()
+            return
+
+        self.register_indicator_for_bars(self.config.bar_type, self.rsi)
+
+        if self.config.request_bars:
+            self.request_bars(
+                self.config.bar_type,
+                start=self._clock.utc_now() - pd.Timedelta(days=1),
+            )
+
+        self.subscribe_bars(self.config.bar_type)
+
+    def on_bar(self, bar: Bar) -> None:
+        self.log.info(repr(bar), LogColor.CYAN)
+
+        if not self.indicators_initialized():
+            self.log.info(
+                f"Waiting for indicator to warm up [{self.cache.bar_count(self.config.bar_type)}]",
+                color=LogColor.BLUE,
+            )
+            return
+
+        if self.rsi.value > self.config.overbought:
+            if self.portfolio.is_net_long(self.config.instrument_id):
+                self.close_all_positions(self.config.instrument_id)
+            if self.portfolio.is_flat(self.config.instrument_id):
+                self.sell()
+        elif self.rsi.value < self.config.oversold:
+            if self.portfolio.is_net_short(self.config.instrument_id):
+                self.close_all_positions(self.config.instrument_id)
+            if self.portfolio.is_flat(self.config.instrument_id):
+                self.buy()
+
+    def buy(self) -> None:
+        order: MarketOrder = self.order_factory.market(
+            instrument_id=self.config.instrument_id,
+            order_side=OrderSide.BUY,
+            quantity=self.create_order_qty(),
+            time_in_force=self.config.order_time_in_force or TimeInForce.GTC,
+        )
+        self.submit_order(order)
+
+    def sell(self) -> None:
+        order: MarketOrder = self.order_factory.market(
+            instrument_id=self.config.instrument_id,
+            order_side=OrderSide.SELL,
+            quantity=self.create_order_qty(),
+            time_in_force=self.config.order_time_in_force or TimeInForce.GTC,
+        )
+        self.submit_order(order)
+
+    def create_order_qty(self) -> Quantity:
+        if self.config.order_quantity_precision is not None:
+            return Quantity(self.config.trade_size, self.config.order_quantity_precision)
+        return self.instrument.make_qty(self.config.trade_size)
+
+    def on_stop(self) -> None:
+        self.cancel_all_orders(self.config.instrument_id)
+        if self.config.close_positions_on_stop:
+            self.close_all_positions(instrument_id=self.config.instrument_id)
+

--- a/nautilus_trader/examples/strategies/sma_cross.py
+++ b/nautilus_trader/examples/strategies/sma_cross.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+"""Simple moving average cross example strategy."""
+
+from decimal import Decimal
+
+import pandas as pd
+
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.config import PositiveInt
+from nautilus_trader.config import StrategyConfig
+from nautilus_trader.core.correctness import PyCondition
+from nautilus_trader.indicators.average.sma import SimpleMovingAverage
+from nautilus_trader.model.data import Bar
+from nautilus_trader.model.data import BarType
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.instruments import Instrument
+from nautilus_trader.model.objects import Quantity
+from nautilus_trader.model.orders import MarketOrder
+from nautilus_trader.trading.strategy import Strategy
+
+
+# *** THIS IS A TEST STRATEGY WITH NO ALPHA ADVANTAGE WHATSOEVER. ***
+# *** IT IS NOT INTENDED TO BE USED TO TRADE LIVE WITH REAL MONEY. ***
+
+
+class SMACrossConfig(StrategyConfig, frozen=True):
+    """Configuration for ``SMACross`` instances."""
+
+    instrument_id: InstrumentId
+    bar_type: BarType
+    trade_size: Decimal
+    fast_sma_period: PositiveInt = 10
+    slow_sma_period: PositiveInt = 20
+    request_bars: bool = True
+    order_time_in_force: TimeInForce | None = None
+    order_quantity_precision: int | None = None
+    close_positions_on_stop: bool = True
+
+
+class SMACross(Strategy):
+    """A basic simple moving average cross strategy."""
+
+    def __init__(self, config: SMACrossConfig) -> None:
+        PyCondition.is_true(
+            config.fast_sma_period < config.slow_sma_period,
+            "{config.fast_sma_period=} must be less than {config.slow_sma_period=}",
+        )
+        super().__init__(config)
+
+        self.instrument: Instrument | None = None
+        self.fast_sma = SimpleMovingAverage(config.fast_sma_period)
+        self.slow_sma = SimpleMovingAverage(config.slow_sma_period)
+
+    def on_start(self) -> None:
+        self.instrument = self.cache.instrument(self.config.instrument_id)
+        if self.instrument is None:
+            self.log.error(f"Could not find instrument for {self.config.instrument_id}")
+            self.stop()
+            return
+
+        self.register_indicator_for_bars(self.config.bar_type, self.fast_sma)
+        self.register_indicator_for_bars(self.config.bar_type, self.slow_sma)
+
+        if self.config.request_bars:
+            self.request_bars(
+                self.config.bar_type,
+                start=self._clock.utc_now() - pd.Timedelta(days=1),
+            )
+
+        self.subscribe_bars(self.config.bar_type)
+
+    def on_bar(self, bar: Bar) -> None:
+        self.log.info(repr(bar), LogColor.CYAN)
+
+        if not self.indicators_initialized():
+            self.log.info(
+                f"Waiting for indicators to warm up [{self.cache.bar_count(self.config.bar_type)}]",
+                color=LogColor.BLUE,
+            )
+            return
+
+        if self.fast_sma.value >= self.slow_sma.value:
+            if self.portfolio.is_flat(self.config.instrument_id):
+                self.buy()
+            elif self.portfolio.is_net_short(self.config.instrument_id):
+                self.close_all_positions(self.config.instrument_id)
+                self.buy()
+        else:
+            if self.portfolio.is_flat(self.config.instrument_id):
+                self.sell()
+            elif self.portfolio.is_net_long(self.config.instrument_id):
+                self.close_all_positions(self.config.instrument_id)
+                self.sell()
+
+    def buy(self) -> None:
+        order: MarketOrder = self.order_factory.market(
+            instrument_id=self.config.instrument_id,
+            order_side=OrderSide.BUY,
+            quantity=self.create_order_qty(),
+            time_in_force=self.config.order_time_in_force or TimeInForce.GTC,
+        )
+        self.submit_order(order)
+
+    def sell(self) -> None:
+        order: MarketOrder = self.order_factory.market(
+            instrument_id=self.config.instrument_id,
+            order_side=OrderSide.SELL,
+            quantity=self.create_order_qty(),
+            time_in_force=self.config.order_time_in_force or TimeInForce.GTC,
+        )
+        self.submit_order(order)
+
+    def create_order_qty(self) -> Quantity:
+        if self.config.order_quantity_precision is not None:
+            return Quantity(self.config.trade_size, self.config.order_quantity_precision)
+        return self.instrument.make_qty(self.config.trade_size)
+
+    def on_stop(self) -> None:
+        self.cancel_all_orders(self.config.instrument_id)
+        if self.config.close_positions_on_stop:
+            self.close_all_positions(instrument_id=self.config.instrument_id)
+


### PR DESCRIPTION
## Summary
- add simple moving average cross strategy with configurable trade size
- add RSI mean reversion strategy and backtests for BTC/USDT

## Testing
- `make ruff`
- `pytest tests/unit_tests/indicators/test_sma.py tests/unit_tests/indicators/test_ma_factory.py` *(fails: ModuleNotFoundError: No module named 'nautilus_trader.core.data')*

------
https://chatgpt.com/codex/tasks/task_e_6894f27e146c8321871883f481588bdd